### PR TITLE
Convert CONTRIBUTORS to markdown using all-contributors-cli

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,0 @@
-@ENT8R
-
-translations:
-German: @rugk
-Spanish: David E. Barrera (@dbarrerap)
-Turkish: Ömür Turan (@omurturan)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,4 +14,4 @@
 
 ### Turkish
 
-- Ömür Turan ([@omurturan](https://github.com/omurturan))
+- Ömür Turan [@omurturan](https://github.com/omurturan)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,17 @@
+# Contributors
+
+- [@ENT8R](https://github.com/ENT8R)
+
+## Translators
+
+### German
+
+- [@rugk](https://github.com/rugk)
+
+### Spanish
+
+- David E. Barrera [@dbarrerap](https://github.com/dbarrerap)
+
+### Turkish
+
+- Ömür Turan ([@omurturan](https://github.com/omurturan))


### PR DESCRIPTION
For #27, I converted CONTRIBUTORS to markdown by [all-contributors-cli](https://allcontributors.org/docs/en/cli/installation), which parses **.all-contributorsrc** file. Its [bot](https://allcontributors.org/docs/en/bot/overview) will also be useful.

Note: I didn't commit **package.json** and **yarn.lock** here.