### PR TITLE
Brazilian portuguese translation

### DIFF
--- a/assets/texts/pt-br/Changelog/1.0.html
+++ b/assets/texts/pt-br/Changelog/1.0.html
@@ -1,0 +1,9 @@
+<ul>
+<li><strong>Featured:</strong> First stable release!</li>
+<li><strong>New:</strong> Options page has been polished.</li>
+<li><strong>New:</strong> The Mastodon handle in the options page is now syntax-checked, so you notice if you enter an invalid one.</li>
+<li><strong>New:</strong> The add-on works on Firefox for Android now.</li>
+<li><strong>Internal:</strong> The add-on now uses <a href="https://github.com/TinyWebEx">many TinyWebEx libraries</a> and <a href="https://github.com/lodash/lodash">lodash</a>.</li>
+</ul>
+
+More information <a href="https://github.com/rugk/mastodon-auto-follow/releases/tag/v1.0">on GitHub</a>.

--- a/assets/texts/pt-br/Changelog/1.0.md
+++ b/assets/texts/pt-br/Changelog/1.0.md
@@ -1,0 +1,5 @@
+* **Featured:** First stable release!
+* **New:** Options page has been polished.
+* **New:** The Mastodon handle in the options page is now syntax-checked, so you notice if you enter an invalid one.
+* **New:** The add-on works on Firefox for Android now.
+* **Internal:** The add-on now uses [many TinyWebEx libraries](https://github.com/TinyWebEx) and [lodash](https://github.com/lodash/lodash).

--- a/assets/texts/pt-br/Changelog/1.2.html
+++ b/assets/texts/pt-br/Changelog/1.2.html
@@ -1,0 +1,9 @@
+<ul>
+<li><strong>New:</strong> Redirecting from Pleroma instances is now supported.</li>
+<li><strong>New:</strong> Notifications are shown if the redirect fails or the add-on is not correctly set up.</li>
+<li><strong>Enhanced:</strong> The verification of the Mastodon account in the options page is now improved, i.e. also checks whether the actual Mastodon account exists.</li>
+<li><strong>Enhanced:</strong> Mastodon toot interaction redirection uses website scraping again as a fallback.</li>
+</ul>
+<strong>Note:</strong> Due to the introduction of error notifications, the add-on requests a new permission to show these notifications. See <a href="https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/en/permissions.md">https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/en/permissions.md</a> for an explanation of all permissions.
+
+More information <a href="https://github.com/rugk/mastodon-auto-follow/releases/tag/v1.2">on GitHub</a>.

--- a/assets/texts/pt-br/Changelog/1.2.md
+++ b/assets/texts/pt-br/Changelog/1.2.md
@@ -1,0 +1,6 @@
+* **New:** Redirecting from Pleroma instances is now supported.
+* **New:** Notifications are shown if the redirect fails or the add-on is not correctly set up.
+* **Enhanced:** The verification of the Mastodon account in the options page is now improved, i.e. also checks whether the actual Mastodon account exists.
+* **Enhanced:** Mastodon toot interaction redirection uses website scraping again as a fallback.
+
+**Note:** Due to the introduction of error notifications, the add-on requests a new permission to show these notifications. See https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/en/permissions.md for an explanation of all permissions.

--- a/assets/texts/pt-br/Changelog/1.3.html
+++ b/assets/texts/pt-br/Changelog/1.3.html
@@ -1,0 +1,11 @@
+<ul>
+    <li><strong>Destaque:</strong> agora você pode contornar o pop-up e carregar diretamente o pop-up no site existente. (<a href="https://github.com/rugk/mastodon-simplified-federation/issues/44">#44</a>)</li>
+    <li><strong>Novo:</strong> o complemento agora suporta o modo de sistema escuro na página de opções.</li>
+    <li><strong>Novo:</strong> o redirecionamento de instâncias do Friendica agora é suportado. (<a href="https://github.com/rugk/mastodon-simplified-federation/issues/20">#20</a>)</li>
+    <li><strong>Novo:</strong> a tradução para espanhol foi adicionada, graças a <a href="https://github.com/dbarrerap">@dbarrerap</a>.</li>
+    <li><strong>Novo:</strong> a tradução para francês foi adicionada, graças a <a href="https://github.com/PoorPocketsMcNewHold">@PoorPocketsMcNewHold</a>.</li>
+    <li><strong>Novo:</strong> a tradução para russo foi adicionada, graças a <a href="https://github.com/katabasiz">@katabasiz</a>.</li>
+    <li><strong>Melhoria:</strong> a tradução para turco foi atualizada, graças a <a href="https://github.com/hozansahin">@hozansahin</a>.</li>
+    </ul>
+    
+    Mais informações <a href="https://github.com/rugk/mastodon-simplified-federation/releases/tag/v1.3">no GitHub</a>.

--- a/assets/texts/pt-br/Changelog/1.3.html
+++ b/assets/texts/pt-br/Changelog/1.3.html
@@ -8,4 +8,4 @@
     <li><strong>Melhoria:</strong> a tradução para turco foi atualizada, graças a <a href="https://github.com/hozansahin">@hozansahin</a>.</li>
 </ul>
     
-    Mais informações <a href="https://github.com/rugk/mastodon-simplified-federation/releases/tag/v1.3">no GitHub</a>.
+Mais informações <a href="https://github.com/rugk/mastodon-simplified-federation/releases/tag/v1.3">no GitHub</a>.

--- a/assets/texts/pt-br/Changelog/1.3.html
+++ b/assets/texts/pt-br/Changelog/1.3.html
@@ -6,6 +6,6 @@
     <li><strong>Novo:</strong> a tradução para francês foi adicionada, graças a <a href="https://github.com/PoorPocketsMcNewHold">@PoorPocketsMcNewHold</a>.</li>
     <li><strong>Novo:</strong> a tradução para russo foi adicionada, graças a <a href="https://github.com/katabasiz">@katabasiz</a>.</li>
     <li><strong>Melhoria:</strong> a tradução para turco foi atualizada, graças a <a href="https://github.com/hozansahin">@hozansahin</a>.</li>
-    </ul>
+</ul>
     
     Mais informações <a href="https://github.com/rugk/mastodon-simplified-federation/releases/tag/v1.3">no GitHub</a>.

--- a/assets/texts/pt-br/Changelog/1.3.md
+++ b/assets/texts/pt-br/Changelog/1.3.md
@@ -1,0 +1,7 @@
+* **Highlight:** You can now circumvent the popup and directly load the popup on the existing site. ([#44](https://github.com/rugk/mastodon-simplified-federation/issues/44))
+* **New:** The add-on now supports the dark system system mode on the options page.
+* **New:** Redirecting from Friendica instances is now supported. ([#20](https://github.com/rugk/mastodon-simplified-federation/issues/20))
+* **New:** The translation for Spanish has been added, thanks to [@dbarrerap](https://github.com/dbarrerap).
+* **New:** The translation for French has been added, thanks to [@PoorPocketsMcNewHold](https://github.com/PoorPocketsMcNewHold).
+* **New:** The translation for Russian has been added, thanks to [@katabasiz](https://github.com/katabasiz).
+* **Improved:** The translation for Turkish has been updated, thanks to [@hozansahin](https://github.com/hozansahin).

--- a/assets/texts/pt-br/Changelog/next.md
+++ b/assets/texts/pt-br/Changelog/next.md
@@ -1,0 +1,1 @@
+* **Corrigido:** Foi corrigido um bug que fazia com que o redirecionamento não fosse capturado no caso de versões mais recentes do Friendica. ([#62](https://github.com/rugk/mastodon-simplified-federation/issues/62))

--- a/assets/texts/pt-br/amoDescription.html
+++ b/assets/texts/pt-br/amoDescription.html
@@ -41,4 +41,4 @@ Ou, em qualquer caso, <a href="https://github.com/rugk/mastodon-simplified-feder
 
 <b>💬 Permissões 💬</b>
 Este complemento requer o mínimo de permissões possível.
-Uma explicação de todas as permissões, solicitações deste complemento, pode ser encontrada <a href="https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/en/permissions.md">neste site</a>.
+Uma explicação de todas as permissões, solicitações deste complemento, pode ser encontrada <a href="https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/pt-br/permissions.md">neste site</a>.

--- a/assets/texts/pt-br/amoDescription.html
+++ b/assets/texts/pt-br/amoDescription.html
@@ -1,0 +1,44 @@
+Este complemento simplifica seguir ou interagir com outros usuários em instâncias remotas do Mastodon no Fediverse. Basicamente, ele pula o pop-up "Enter your Mastodon handle" e leva você diretamente para sua própria instância "home", evitando que você insira seu handle Mastodon repetidamente nessa caixa de entrada quando você clica em "Follow", "Retoot "/"Fav" ou outro botão de interação remota em outra instância.
+
+
+<b>🤯 Por quê? 🤯</b>
+Você pode se perguntar por que usar este complemento do navegador. Mas, na verdade, é fácil!
+
+Você <b>não precisa mais entrar</b> no seu identificador de conta Mastodon! (exceto no login 😉) Isso torna a interação com instâncias remotas no Fediverse muito mais simples.
+
+Além disso, este complemento garante que seu identificador Mastodon seja <b>privado</b>. Ele nunca irá expô-lo a nenhum site de terceiros. Portanto, ele não insere – literalmente – seu ID do Mastodon no campo de entrada que você normalmente vê, mas basicamente “pula” esta página. Para obter detalhes técnicos sobre como ele funciona, consulte <a href="https://github.com/rugk/mastodon-simplified-federation#how-does-it-work" title="Como funciona?"> a explicação detalhada no GitHub</a>.
+
+
+<b>🐤 Como usar? 🐤</b>
+Depois de instalar o complemento, você precisa ir para as configurações, digite seu identificador Mastodon (que é <code>nome_de_usuario@servidor</code>). Feito isso, não há mais nada que você precise fazer. O complemento continuará funcionando em segundo plano e você não precisará fazer nada.
+Apenas aproveite a federação simplificada quando estiver sendo redirecionado automaticamente quando quiser seguir ou interagir com um usuário.
+
+
+<b>🤔 O que é Mastodon? 🤔</b>
+Mastodon é uma nova e amigável rede social descentralizada. Para ser exato, é “federado”, ou seja, você tem sua própria conta de usuário em um servidor e pode seguir e interagir com outros usuários em diferentes servidores.
+Para isso, você geralmente precisa inserir seu ID Mastodon nesses servidores “estrangeiros”, para que eles saibam para qual servidor devem redirecionar. Este complemento remove, respectivamente automatiza, esta etapa.
+Saiba mais sobre o Mastodon em <a href="https://joinmastodon.org/">joinmastodon.org</a>.
+
+
+<b>🤠 Suporte estendido 🤠</b>
+Este complemento suporta redirecionamentos de outros sistemas no Fediverse, nomeadamente GNU Social, Friendica e Pleroma. Especialmente no primeiro caso, no entanto, o suporte pode ser um pouco limitado.
+
+
+<b>📝 Desenvolvimento 📝</b>
+O complemento é um software de código aberto gratuito/livre e desenvolvido no GitHub. <a href="https://github.com/rugk/mastodon-simplified-federation">Fork ele no GitHub</a> e contribua.
+<a href="https://github.com/rugk/mastodon-simplified-federation/contribute">Há alguns problemas simples para começar.</a> Ou você pode <a href="https://github .com/rugk/mastodon-simplified-federation/blob/master/CONTRIBUTING.md#translations">traduzir o complemento para seu próprio idioma.</a>
+
+
+<b>🙋‍♀️ Contribua 🙋‍♀️</b>
+Você pode facilmente se envolver neste projeto e ajudar. Aqui estão algumas ideias:
+<ul>
+<li>📃 <a href="https://github.com/rugk/mastodon-simplified-federation/blob/master/CONTRIBUTING.md#translations">Traduza este complemento para vários idiomas!</a></li>
+<li>🐛 <a href="https://github.com/rugk/mastodon-simplified-federation/blob/master/CONTRIBUTING.md#coding">Corrija alguns problemas simples e comece a desenvolver complementos</a> (ou apenas experimente a versão de desenvolvimento)</li>
+<li>💡 <a href="https://github.com/rugk/mastodon-simplified-federation/blob/master/CONTRIBUTING.md#need-ideas">Ou confira alguns outros problemas adicionais</a > (ou traduzi-los).</li>
+</ul>
+Ou, em qualquer caso, <a href="https://github.com/rugk/mastodon-simplified-federation/blob/master/CONTRIBUTING.md#support-us">apoie-nos divulgando!</a > ❤️
+
+
+<b>💬 Permissões 💬</b>
+Este complemento requer o mínimo de permissões possível.
+Uma explicação de todas as permissões, solicitações deste complemento, pode ser encontrada <a href="https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/en/permissions.md">neste site</a>.

--- a/assets/texts/pt-br/amoScreenshots.csv
+++ b/assets/texts/pt-br/amoScreenshots.csv
@@ -1,0 +1,5 @@
+remoteFollow.png; "Se você seguir alguém de uma instância remota...";
+remoteFollowRedirectCropped.png; "…ele é redirecionado automaticamente,";
+interactWithToot.png; "…ou se você interagir com um toot,";
+interactWithTootRedirect.png; "…, também é redirecionado.";
+settings.png; "Tudo é feito automaticamente em segundo plano. Você só precisa digitar uma coisa: seu identificador de Mastodon.";

--- a/assets/texts/pt-br/amoSummary.txt
+++ b/assets/texts/pt-br/amoSummary.txt
@@ -1,0 +1,1 @@
+Simplifica seguir ou interagir com outros usuários em instâncias remotas do Mastodon no Fediverse. Ele pula o pop-up “Enter your Mastodon handle” e leva você para sua própria instância “home”, sem inserir seu handle Mastodon em instâncias remotas.

--- a/assets/texts/pt-br/permissions.md
+++ b/assets/texts/pt-br/permissions.md
@@ -1,6 +1,6 @@
 # Permissões solicitadas
 
-Para uma explicação geral da permissão de complemento, consulte [this support article](https://support.mozilla.org/kb/permission-request-messages-firefox-extensions).
+Para uma explicação geral da permissão de complemento, consulte [este artigo de suporte](https://support.mozilla.org/kb/permission-request-messages-firefox-extensions).
 
 ## Permissões de instalação
 

--- a/assets/texts/pt-br/permissions.md
+++ b/assets/texts/pt-br/permissions.md
@@ -1,0 +1,18 @@
+# Permissões solicitadas
+
+Para uma explicação geral da permissão de complemento, consulte [this support article](https://support.mozilla.org/kb/permission-request-messages-firefox-extensions).
+
+## Permissões de instalação
+
+| Id Interno                  | Permissão                         | Explicação                                                                                                                                                                                                                                                                                                                     |
+|:----------------------------|:----------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `http://*/*`, `https://*/*` | Acessa seus dados para todos os sites | Necessário para obter acesso a qualquer site de um servidor que possa ser uma instância do Mastodon. Como qualquer servidor pode ser uma instância do Mastodon, ele precisa ter acesso a todos [HTTP](https://en.wikipedia.org/wiki/HTTP) and [HTTPS](https://en.wikipedia.org/wiki/HTTPS) [URLs](https://en.wikipedia.org/wiki/Uniform_Resource_Locator). |
+| `notifications` | Exibir notificações para você | Necessário para mostrar uma notificação caso o redirecionamento ou outra coisa falhe. |
+
+## Permissões ocultas
+Além disso, ele solicita essas permissões, que não são solicitadas no Firefox quando o complemento é instalado, pois não são uma permissão profunda.
+
+| Id Interno   | Permissão            | Explicação                                                                                                                                |
+|:-------------|:---------------------|:-------------------------------------------------------------------------------------------------------------------------------------------|
+| `webRequest` | Acessar solicitações da web  | Necessário para redirecionamento de [URLs](https://en.wikipedia.org/wiki/Uniform_Resource_Locator) para o servidor, onde você tem sua conta Mastodon. |
+| `storage`    | Acesse o armazenamento local | Necessário para salvar opções                                                                                                                  |

--- a/assets/texts/pt-br/privacy.txt
+++ b/assets/texts/pt-br/privacy.txt
@@ -1,0 +1,32 @@
+Definitions:
+ADD-ON – the software that this policy applies to
+USER – the USER of the ADD-ON
+REMOTE SERVER – a server on the internet, identified by a server address (domain name)
+REMOTE USER – a USER account saved on a server on the internet, consists of a USER's name and the server address a USER is registered on, the REMOTE SERVER
+REMOTE MESSAGE – any form of message, including but not limited to text, multimedia, audio and video; published by a REMOTE USER and saved on a REMOTE SERVER
+
+This ADD-ON does not send any personally identifiable information to the ADD-ON author.
+
+OWN ACCOUNT – a USER account saved on a server on the internet, consists of a USER's name and the server address, the USER of the ADD-ON has declared in the settings of this ADD-ON that this account is owned by them
+OWN SERVER – the server on the internet, identified by a server address (domain name); the USER of the ADD-ON has declared in the settings of this ADD-ON to have saved it's OWN ACCOUNT on this server
+
+If an Uniform Resource Locator (URL) in a specified way is accessed, that indicates you are trying to follow REMOTE USER or otherwise interact with the REMOTE USER or a REMOTE MESSAGE published by a REMOTE USER on a REMOTE SERVER, it can redirect the USER to a server you have specified in the settings of the ADD-ON as an OWN SERVER.
+To do so, the ADD-ON may contact the REMOTE SERVER and LOCAL SERVER and send information about the REMOTE USER and REMOTE MESSAGE.
+Additionally, it may send information about the OWN ACCOUNT and OWN SERVER to OWN SERVER.
+
+The ADD-ON will not send information about your OWN ACCOUNT or OWN SERVER to any REMOTE SERVER. If that case should inadvertently happen, it is considered a vulnerability in the ADD-ON.
+It may happen, however, that the REMOTE SERVER is the same as the OWN SERVER. In such a case, the ADD-ON works the same and may thus send all the information to it's own server.
+
+An explanation of all permissions, this ADD-ON requests, can be found at https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/en/permissions.md.
+
+== IMPLICATIONS ==
+
+There are two implications this add-on causes:
+1. As the USER does not need to enter your Mastodon handle anymore on any website, this can result in a privacy advantage.
+2. However, please mind that websites may still detect that the USER uses this add-on by triggering a redirect as if the USER clicked on a button. The USER will likely see this.
+
+== THIRD-PARTY SERVICES ==
+
+This ADD-ON uses the “sync storage” of your browser to store the settings. If the USER enables “Sync” in the browser, the settings are uploaded and synchronized across your devices connected to your account. If you do not do, the data is only stored locally on your device.
+In Mozilla Firefox the data is end-to-end encrypted before getting uploaded and stored on servers by Mozilla.
+See https://accounts.firefox.com/legal/privacy and https://www.mozilla.org/privacy/firefox/#c-privacy-topic-8 for Mozilla's privacy policies on that topic.

--- a/assets/texts/pt-br/privacy.txt
+++ b/assets/texts/pt-br/privacy.txt
@@ -1,32 +1,32 @@
-Definitions:
-ADD-ON – the software that this policy applies to
-USER – the USER of the ADD-ON
-REMOTE SERVER – a server on the internet, identified by a server address (domain name)
-REMOTE USER – a USER account saved on a server on the internet, consists of a USER's name and the server address a USER is registered on, the REMOTE SERVER
-REMOTE MESSAGE – any form of message, including but not limited to text, multimedia, audio and video; published by a REMOTE USER and saved on a REMOTE SERVER
+Definições:
+COMPLEMENTO – o software ao qual esta política se aplica
+USUÁRIO – o USUÁRIO do COMPLEMENTO
+SERVIDOR REMOTO – um servidor na internet, identificado por um endereço de servidor (nome de domínio)
+USUÁRIO REMOTO – uma conta de USUÁRIO salva em um servidor na internet, consiste no nome de um USUÁRIO e no endereço do servidor no qual um USUÁRIO está registrado, o SERVIDOR REMOTO
+MENSAGEM REMOTA – qualquer forma de mensagem, incluindo, mas não se limitando a texto, multimídia, áudio e vídeo; publicado por um USUÁRIO REMOTO e salvo em um SERVIDOR REMOTO
 
-This ADD-ON does not send any personally identifiable information to the ADD-ON author.
+Este COMPLEMENTO não envia nenhuma informação de identificação pessoal ao autor do COMPLEMENTO.
 
-OWN ACCOUNT – a USER account saved on a server on the internet, consists of a USER's name and the server address, the USER of the ADD-ON has declared in the settings of this ADD-ON that this account is owned by them
-OWN SERVER – the server on the internet, identified by a server address (domain name); the USER of the ADD-ON has declared in the settings of this ADD-ON to have saved it's OWN ACCOUNT on this server
+CONTA PRÓPRIA – uma conta de USUÁRIO salva em um servidor na internet, consiste no nome de um USUÁRIO e no endereço do servidor, o USUÁRIO do COMPLEMENTO declarou nas configurações deste COMPLEMENTO que esta conta é de sua propriedade
+SERVIDOR PRÓPRIO – o servidor na internet, identificado por um endereço de servidor (nome de domínio); o USUÁRIO do COMPLEMENTO declarou nas configurações deste COMPLEMENTO ter salvo sua PRÓPRIA CONTA neste servidor
 
-If an Uniform Resource Locator (URL) in a specified way is accessed, that indicates you are trying to follow REMOTE USER or otherwise interact with the REMOTE USER or a REMOTE MESSAGE published by a REMOTE USER on a REMOTE SERVER, it can redirect the USER to a server you have specified in the settings of the ADD-ON as an OWN SERVER.
-To do so, the ADD-ON may contact the REMOTE SERVER and LOCAL SERVER and send information about the REMOTE USER and REMOTE MESSAGE.
-Additionally, it may send information about the OWN ACCOUNT and OWN SERVER to OWN SERVER.
+Se um Uniform Resource Locator (URL) de uma forma especificada for acessado, isso indica que você está tentando seguir o USUÁRIO REMOTO ou de outra forma interagir com o USUÁRIO REMOTO ou uma MENSAGEM REMOTA publicada por um USUÁRIO REMOTO em um SERVIDOR REMOTO, ele pode redirecionar o USUÁRIO para um servidor que você especificou nas configurações do COMPLEMENTO como um SERVIDOR PRÓPRIO.
+Para tanto, o COMPLEMENTO poderá entrar em contato com o SERVIDOR REMOTO e LOCAL SERVER e enviar informações sobre o USUÁRIO REMOTO e MENSAGEM REMOTA.
+Além disso, pode enviar informações da PRÓPRIA CONTA e PRÓPRIO SERVIDOR para PRÓPRIO SERVIDOR.
 
-The ADD-ON will not send information about your OWN ACCOUNT or OWN SERVER to any REMOTE SERVER. If that case should inadvertently happen, it is considered a vulnerability in the ADD-ON.
-It may happen, however, that the REMOTE SERVER is the same as the OWN SERVER. In such a case, the ADD-ON works the same and may thus send all the information to it's own server.
+O COMPLEMENTO não enviará informações sobre sua CONTA PRÓPRIA ou SERVIDOR PRÓPRIO para nenhum SERVIDOR REMOTO. Se esse caso ocorrer inadvertidamente, é considerado uma vulnerabilidade no COMPLEMENTO.
+Pode acontecer, porém, que o SERVIDOR REMOTO seja o mesmo que o SERVIDOR PRÓPRIO. Nesse caso, o COMPLEMENTO funciona da mesma forma, podendo assim enviar toda a informação para o seu próprio servidor.
 
-An explanation of all permissions, this ADD-ON requests, can be found at https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/en/permissions.md.
+Uma explicação de todas as permissões, solicitações deste COMPLEMENTO, pode ser encontrada em https://github.com/rugk/mastodon-simplified-federation/blob/master/assets/texts/en/permissions.md.
 
-== IMPLICATIONS ==
+== IMPLICAÇÕES ==
 
-There are two implications this add-on causes:
-1. As the USER does not need to enter your Mastodon handle anymore on any website, this can result in a privacy advantage.
-2. However, please mind that websites may still detect that the USER uses this add-on by triggering a redirect as if the USER clicked on a button. The USER will likely see this.
+Há duas implicações que esse complemento causa:
+1. Como o USUÁRIO não precisa mais inserir seu identificador Mastodon em nenhum site, isso pode resultar em uma vantagem de privacidade.
+2. No entanto, lembre-se de que os sites ainda podem detectar que o USUÁRIO usa esse complemento acionando um redirecionamento como se o USUÁRIO tivesse clicado em um botão. O USUÁRIO provavelmente verá isso.
 
-== THIRD-PARTY SERVICES ==
+== SERVIÇOS DE TERCEIROS ==
 
-This ADD-ON uses the “sync storage” of your browser to store the settings. If the USER enables “Sync” in the browser, the settings are uploaded and synchronized across your devices connected to your account. If you do not do, the data is only stored locally on your device.
-In Mozilla Firefox the data is end-to-end encrypted before getting uploaded and stored on servers by Mozilla.
-See https://accounts.firefox.com/legal/privacy and https://www.mozilla.org/privacy/firefox/#c-privacy-topic-8 for Mozilla's privacy policies on that topic.
+Este COMPLEMENTO usa o “armazenamento de sincronização” do seu navegador para armazenar as configurações. Se o USUÁRIO habilitar “Sincronizar” no navegador, as configurações serão carregadas e sincronizadas em seus dispositivos conectados à sua conta. Se você não fizer isso, os dados serão armazenados apenas localmente em seu dispositivo.
+No Mozilla Firefox, os dados são criptografados de ponta a ponta antes de serem carregados e armazenados em servidores pela Mozilla.
+Consulte https://accounts.firefox.com/legal/privacy e https://www.mozilla.org/privacy/firefox/#c-privacy-topic-8 para obter as políticas de privacidade da Mozilla sobre esse tópico.

--- a/src/_locales/pt-br/messages.json
+++ b/src/_locales/pt-br/messages.json
@@ -1,0 +1,249 @@
+{
+  // manifest.json
+  "extensionName": {
+    "message": "Mastodon – Simplified Federation!",
+    "description": "Name of the extension.",
+    "hash": "8c716f7803f220414804500b514a1dc0"
+  },
+  "extensionNameShort": {
+    "message": "Mastodon – Simplified Federation!",
+    "description": "Name of the extension.",
+    "hash": "8c716f7803f220414804500b514a1dc0"
+  },
+  "extensionDescription": {
+    "message": "Simplifica seguir ou interagir com outros usuários em instâncias remotas do Mastodon.",
+    "hash": "61083256339a41f90d4db1bfa89532b6"
+  },
+
+  // errors or other messages (mostly for settings)
+  "errorShowingMessage": {
+    "message": "Não foi possível mostrar esta mensagem.",
+    "description": "When there is an error when showing the error/info/….",
+    "hash": "a9440e4f824a372841d4de2b7e2643ee"
+  },
+  "couldNotLoadOptions": {
+    "message": "Não foi possível carregar as configurações.",
+    "description": "When one or all settings could not be loaded.",
+    "hash": "9497a5d2c9473aeb2ed9601f46c456be"
+  },
+  "couldNotSaveOption": {
+    "message": "Não foi possível salvar esta configuração.",
+    "description": "When a setting could not be saved.",
+    "hash": "6bcb9e36d2c33172b948515a9c50aa8e"
+  },
+  "messageUndoButton": {
+    "message": "Desfazer",
+    "description": "The text of a button that undoes the last action.",
+    "hash": "a85e775d7404b86c8060a20efd31241c"
+  },
+  "couldNotUndoAction": {
+    "message": "Não foi possível desfazer a ação.",
+    "description": "Shown when an action cannot be undone.",
+    "hash": "d2883c6ca0164afc4f360f3e02e3166a"
+  },
+  "resettingOptionsWorked": {
+    "message": "Todas as configurações estão agora de volta aos padrões!",
+    "description": "The message shown, when the options of the settings were reset.",
+    "hash": "257b99ed2a074fccbfc658d770b50107"
+  },
+  "resettingOptionsFailed": {
+    "message": "Não foi possível redefinir as opções!",
+    "description": "The message shown, when the options of the settings could not have been reset.",
+    "hash": "76e950d2db72a824482411ca6564fb1f"
+  },
+
+  // errors or other messages for specific settings
+  "mastodonHandleIsEmpty": {
+    "message": "Por favor, entre com uma conta Mastodon. Sem isso, o complemento não funcionará.",
+    "description": "This is an error shown, when the user did not (yet) enter a Mastodon account.",
+    "hash": "ee5babc05bd20be8fc70189b26c31fc8"
+  },
+  "mastodonHandleIsInvalid": {
+    "message": "A conta Mastodon inserida é inválida.",
+    "description": "This is an error shown, when the Mastodon handle the user entered is not valid.",
+    "hash": "6cf4f0cecc601398c99f9a1afab1dc09"
+  },
+  "mastodonHandleDoesNotExist": {
+    "message": "O usuário do Mastodon fornecido não existe nesse servidor.",
+    "description": "This is an error shown, when the Mastodon handle the user entered does not exist on the server, i.e. the server returns a 404 error.",
+    "hash": "510bf6395054f816063b1dbb6b226b8c"
+  },
+  "mastodonHandleServerCouldNotBeContacted": {
+    "message": "O servidor (Mastodon) fornecido não pôde ser contatado.",
+    "description": "This is an error shown, when the last part of Mastodon handle (= the server) could not be contacted, due to a network (likely DNS) error and thus likely due to a typo or another problem.",
+    "hash": "77c3f0fc23bc9a39d82d6ba80def8fdb"
+  },
+  "isNoMastodonServer": {
+    "message": "O servidor fornecido não é uma instância do Mastodon.",
+    "description": "This is an error shown, when the last part of Mastodon handle (= the server) is actually no Mastodon server.",
+    "hash": "a32698c492feb27656ece403e4bb5d3f"
+  },
+  "mastodonHandleCheckFailed": {
+    "message": "Falha na verificação da conta Mastodon inserida.",
+    "description": "This is an error shown, when the server that has been contacted to verify the handle returned an unexpected response.",
+    "hash": "63eda9bccc85c46e7694fb4ec9a7527d"
+  },
+  "addonIsNotYetSetup": {
+    "message": "Este complemento ainda não está configurado. Você precisa inserir sua conta Mastodon nas configurações.",
+    "description": "This is an error shown, when the user did not (yet) setup the whole add-on. Semantically it is the same as mastodonHandleIsEmpty, but this one is used in the notification.",
+    "hash": "bbc3ea93d61ef757d572c5e8a67462d8"
+  },
+  "couldNotRedirect": {
+    "message": "Não foi possível redirecionar devido a um erro inesperado.",
+    "description": "Generic error shown when redirecting fails.",
+    "hash": "e46a9b3ba7502d7b5d399f0b9461fc82"
+  },
+  "permissionRequiredTabs": {
+    "message": "A permissão para acessar as guias do navegador é necessária para esse recurso.",
+    "description": "The message shown, when the emojiCopyOnlyFallback option in the settings needs to request permissions to work.",
+    "hash": "dce672ef8e244e85b5972c4c4b885a56"
+  },
+  "buttonRequestPermission": {
+    "message": "Conceder permissão",
+    "description": "The button label, used for requesting a permission that is missing.",
+    "hash": "4689dc838288903e92432d87c1b8fea2"
+  },
+  "couldNotRequestPermission": {
+    "message": "Falha ao solicitar permissão.",
+    "description": "When the permission request fails.",
+    "hash": "53e3617a82c33e20fb22eed64dced8de"
+  },
+
+  // notification errors
+  "errorNotificationRedirectingTitle": {
+    "message": "“$ADDON$” não conseguiu redirecionar",
+    "description": "Title of a notification if an error is shown when trying to redirect.",
+    "placeholders": {
+      "addon": { "content": "$1", "example": "Mastodon – Simplified Federation!" }
+    },
+    "hash": "22b6584d75bbe237f649b1acb1368f3e"
+  },
+  "errorNotificationNotSetupTitle": {
+    "message": "“$ADDON$” ainda não foi configurado",
+    "description": "Title of a notification if an error is shown when the add-on is not set up yet. In contrast to errorNotificationRedirectingTitle this is only shown for this one error. See also addonIsNotYetSetup.",
+    "placeholders": {
+      "addon": { "content": "$1", "example": "Mastodon – Simplified Federation!" }
+    },
+    "hash": "293c7d2237453337466f497c7f96a483"
+  },
+  "errorNotificationAdjustSettings": {
+    "message": "$ERROR$ Clique para ajustar as configurações.",
+    "description": "Wrapper shown if an error happened to point the user to the settings. It is used in the description of the notification.",
+    "placeholders": {
+      "error": { "content": "$1", "example": "Please enter a Mastodon handle. Without it, the add-on will not work." }
+    },
+    "hash": "bb59597ed9b522c05b451cb4dce628e3"
+  },
+
+  // options
+  "someSettingsAreManaged": {
+    "message": "Algumas configurações são gerenciadas pelo administrador do sistema e não podem ser alteradas.",
+    "description": "The message, which appears, when settings are pre-defined (as managed options) by administrators.",
+    "hash": "148604ebbeb7df28974d8233f1418d1f"
+  },
+  "optionIsDisabledBecauseManaged": {
+    "message": "Esta opção está desabilitada porque foi configurada pelo administrador do sistema.",
+    "description": "The title (tooltip) shown, when hovering over a disabled, managed option.",
+    "hash": "50fb70682c64e1a1fb4d8884b33cca64"
+  },
+  "optionLearnMore": {
+    "message": "Saiba mais",
+    "description": "When a link to an explainer needs to be added, this is the link text.",
+    "hash": "9085b09f4748be12ab0c241d2e643b31"
+  },
+  "optionsResetButton": {
+    "message": "Redefinir todas as configurações para os padrões",
+    "description": "The button to delete all current settings and load the defaults, shown in the add-on settings.",
+    "hash": "4bb60c6c7e7b9e2ff987c244e76ee044"
+  },
+  "optionMastodonHandle": {
+    "message": "Sua conta Mastodon:",
+    "description": "This is an option shown in the add-on settings. You can enter your handle in the format mastodon@server.com there.",
+    "hash": "c3056895503de22349f1b77062b3bbd3"
+  },
+  "optionMastodonHandlePlaceholder": {
+    "message": "voce@mastodon.example",
+    "description": "This is placeholder shown for the Mastodon handle input. Try to give an example on format the user has to use to enter the ID as  mastodon@server.com here. Do not use a real server name and do not promote any really existing user.",
+    "hash": "9a20059d2d16dfb7e731226187c04836"
+  },
+  "optionMastodonHandleHelper": {
+    "message": "Por favor, insira seu identificador Mastodon no formato “usuario@dominio”.",
+    "description": "An explanatory text shown to the user in the settings to explain what format they have to enter the Mastodon handle. It should not hint to any example (that's what the placeholder is for), but explain the general format.",
+    "hash": "5e2a6e34c5fed46740dc238f1cc7768a"
+  },
+  "optionRedirectInMainWindow": {
+    "message": "Impedir o uso de pop-ups.",
+    "description": "This is an option shown in the add-on settings.",
+    "hash": "dc056fc373c7161104ad81b28884a017"
+  },
+  "optionRedirectInMainWindowDescr": {
+    "message": "Impede o uso de uma janela extra e redireciona a ação na página principal.",
+    "description": "This is an option shown in the add-on settings.",
+    "hash": "ba0f60f1ae0c6d6785d5eb410247eb11"
+  },
+  "translatorCredit": {
+    "message": "Este complemento foi traduzido para o inglês por $TRANSLATORS$.",
+    "description": "The credit text for the translator. See https://github.com/TinyWebEx/common/blob/master/CONTRIBUTING.md#translator-credit-inside-of-add-on for how to translate this.",
+    "placeholders": {
+      "translators": { "content": "$1", "example": "<a href=\"https://github.com/rugk/\">@rugk</a>" }
+    },
+    "hash": "a6f5deecd624d5f8cd58350c72dd8fdf"
+  },
+  "translatorLink": {
+    "message": "https://pauloroger.dev/",
+    "description": "The link to the translator's GitHub profile.",
+    "hash": "4775fb2f88fd33d02b871e5021dec3e9"
+  },
+  "translatorUsername": {
+    "message": "Paulo Roger",
+    "description": "The username that the translator wants to be referred to.",
+    "hash": "ce96c18a8a1b4b528b294e981ee4d651"
+  },
+  "contributorsThanks": {
+    "message": "Agradecimentos também a $CONTRIBUTORS$.",
+    "description": "Text thanking all contributors and linking to the contributors file.",
+    "placeholders": {
+      "contributors": { "content": "$1", "example": "<a href=\"https://github.com/rugk/…/CONTRIBUTORS.md\">all other contributors</a>" }
+    },
+    "hash": "b1434b8b42b1707f37d0531a8efdc7f8"
+  },
+  "contributorsThanksLink": {
+    "message": "https://github.com/rugk/mastodon-simplified-federation/blob/master/CONTRIBUTORS.md",
+    "description": "The link to the CONTRIBUTORS file.",
+    "hash": "1fbeb3813910bf47c53cf596035c27db"
+  },
+  "contributorsThanksLinkText": {
+    "message": "todos os outros contribuidores",
+    "description": "The link text linking to the contributors file. See contributorsThanks.",
+    "hash": "ce03e1f3b15df3bba66048b30c4f8de4"
+  },
+
+  // ARIA labels/descriptions for messages
+  "dismissIconDescription": {
+    "message": "Fechar esta mensagem",
+    "description": "the aria label for the close button of the message box",
+    "hash": "632720ab193dcacba4286cb364124856"
+  },
+  "ariaMessageInfo": {
+    "message": "mensagem informativa",
+    "description": "the aria label to label the message box as an info message box",
+    "hash": "5f54e42067e19895a2641b17a5233418"
+  },
+  "ariaMessageSuccess": {
+    "message": "mensagem de êxito",
+    "description": "the aria label to label the message box as an success message box",
+    "hash": "334387b4ae53483d17f11519a70dd3af"
+  },
+  "ariaMessageError": {
+    "message": "mensagem de erro",
+    "description": "the aria label to label the message box as an error message box",
+    "hash": "fcda6eedc61727fe8aae7392a0a541a5"
+  },
+  "ariaMessageWarning": {
+    "message": "mensagem de aviso",
+    "description": "the aria label to label the message box as an warning message box",
+    "hash": "8a5dd7528bead1ccd27cb7430d797bd2"
+  },
+
+  "__WET_LOCALE__": { "message": "pt-br" }
+}


### PR DESCRIPTION
Added the brazilian portuguese translation to the add-on following the guides from mozilla.
translated also the description, permissions explanation, privacy note, the most recent changelog (html) and the next.md.