### PR TITLE
fix: properly fallback in case of error/rejection of one Toot-ID getting method

### DIFF
--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -41,7 +41,7 @@
   "applications": {
     "gecko": {
       "id": "mastodon-auto-remote-follow@rugk.github.io",
-      "strict_min_version": "61.0"
+      "strict_min_version": "79.0"
     }
   }
 }

--- a/src/background/modules/Detect/Mastodon.js
+++ b/src/background/modules/Detect/Mastodon.js
@@ -161,7 +161,7 @@ export function getTootUrl(url) {
     // methods.
     return fromStaticOwnServer.catch(() => {
         // prefer fastest result
-        return Promise.race([getFromApiQuery, scrapFromHtml]);
+        return Promise.any([getFromApiQuery, scrapFromHtml]);
     }).then((url) => {
         // log result for debugging purposes
         console.log(`Got toot URL "${url}".`, {fromStaticOwnServer, getFromApiQuery, scrapFromHtml});

--- a/src/common/modules/MastodonApi.js
+++ b/src/common/modules/MastodonApi.js
@@ -87,6 +87,7 @@ export function isMastodonServer(mastodonServer) {
  * @param {string} mastodonServer Mastodon server domain to query
  * @param {string} localTootId local ID of the toot
  * @returns {Promise} an (JSON) object
+ * @throws {MastodonApiError} in case the data cannot be fetched
  */
 export function getTootStatus(mastodonServer, localTootId) {
     // protcol specified HTTPS must be used

--- a/src/common/modules/NetworkTools.js
+++ b/src/common/modules/NetworkTools.js
@@ -64,6 +64,7 @@ export function fetch(input, init = {}, ...args) {
     let abortTimeoutId;
 
     if (!init.signal) {
+        // replace with AbortSignal.timeout(5000) if that is browser cross-compatible
         abortTimeoutId = setTimeout(() => abortController.abort(), 5000);
         init.signal = abortController.signal;
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -42,7 +42,7 @@
   "applications": {
     "gecko": {
       "id": "mastodon-auto-remote-follow@rugk.github.io",
-      "strict_min_version": "61.0"
+      "strict_min_version": "79.0"
     }
   }
 }


### PR DESCRIPTION
To implement such a fallback mechanism the extension races two promises against each other here, which have these two methods implemented:
https://github.com/rugk/mastodon-simplified-federation/blob/e34050284bf2d614d694067ff32005eebd1f6427/src/background/modules/Detect/Mastodon.js#L164

[Promise.race](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race) just has the [issue that it also rejects as soon as a promise rejects, i.e. errors](https://stackoverflow.com/questions/70747069/why-does-promise-race-fulfill-with-an-unfulfilled-promise).
That's actually not what we want. That works, as long as the success comes _before_ the error, but if the error is instant (which is nearly always the case here because the JSON API is faster than website scraping), then it fails.

We want to ignore errors. I.e. I found [something like this SO questions asks for](https://stackoverflow.com/questions/37234191/how-do-you-implement-a-racetosuccess-helper-given-a-list-of-promises), which [points to the modern browser-implemented solution](https://stackoverflow.com/a/60274215/5008962) called [`Promise.any`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/any).

Also needs bumping the Firefox version, but that is not a problem, as that version is really old enough to not be supported anymore. :D

---

_Also_ implemented a timeout for the API request, so it cannot be stale and hang around forever, which may be bad, too. (At some point we want to show the user an error, after all.)

Fixes #71 