### PR TITLE
feat: inject content script to handle follows from remote v4 Mastodon instances

### DIFF
--- a/src/background/modules/AutoRemoteFollow.js
+++ b/src/background/modules/AutoRemoteFollow.js
@@ -145,12 +145,13 @@ function getInteractionType(url) {
 }
 
 /**
- * Handles changes to the URL of a tab
+ * Handles changes to the URL of a tab.
+ * @returns {void}
  */
 function onTabUpdate() {
     browser.tabs.executeScript(null, {
-        file: `/content_script/mastodonInject.js`
-    })
+        file: "/content_script/mastodonInject.js"
+    });
 }
 
 /**

--- a/src/background/modules/AutoRemoteFollow.js
+++ b/src/background/modules/AutoRemoteFollow.js
@@ -149,7 +149,7 @@ function getInteractionType(url) {
  * @returns {void}
  */
 function onTabUpdate() {
-    browser.tabs.executeScript(null, {
+    browser.tabs.executeScript({
         file: "/content_script/mastodonInject.js"
     });
 }

--- a/src/background/modules/AutoRemoteFollow.js
+++ b/src/background/modules/AutoRemoteFollow.js
@@ -145,6 +145,15 @@ function getInteractionType(url) {
 }
 
 /**
+ * Handles changes to the URL of a tab
+ */
+function onTabUpdate() {
+    browser.tabs.executeScript(null, {
+        file: `/content_script/mastodonInject.js`
+    })
+}
+
+/**
  * Init AutoRemoteFollower module.
  *
  * @function
@@ -153,6 +162,10 @@ function getInteractionType(url) {
 function init() {
     NetworkTools.webRequestListen(["http://*/*", "https://*/*"], "onBeforeRequest", (requestDetails) => {
         return handleWebRequest(requestDetails).catch(handleError).catch(console.error);
+    });
+
+    browser.tabs.onUpdated.addListener(onTabUpdate, {
+        properties: ["url"]
     });
 }
 

--- a/src/common/modules/NetworkTools.js
+++ b/src/common/modules/NetworkTools.js
@@ -38,7 +38,7 @@ function convertUrlToString(url) {
  */
 export function fetch(input, init = {}, ...args) {
     const USER_AGENT_HEADER = "User-Agent";
-    const USER_AGENT_VALUE = `${ADDON_NAME_INTERNAL} (v${ADDON_VERSION}; https://github.com/rugk/mastodon-auto-follow; on ${BROWSER_IDENTIFIER})`;
+    const USER_AGENT_VALUE = `${ADDON_NAME_INTERNAL} (v${ADDON_VERSION}; https://github.com/rugk/mastodon-simplified-federation; on ${BROWSER_IDENTIFIER})`;
 
     // init header object, if needed
     if (!(init.headers instanceof Headers)) {

--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -10,9 +10,9 @@
  * @returns {VersionNumber}
  */
 function parseVersionNumber() {
-  const versionElement = document.querySelector(`.link-footer`).textContent
-  const versionNumber = versionElement.match(/v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$/)
-  return versionNumber.groups
+  const versionElement = document.querySelector(`.link-footer`).textContent;
+  const versionNumber = versionElement.match(/v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$/);
+  return versionNumber.groups;
 }
 
 
@@ -20,81 +20,82 @@ function parseVersionNumber() {
  * Replacement onClick handler for Follow button
  * @param {Event} event 
  */
-function onClickFollow (event) {
-  event.stopPropagation()
-  event.preventDefault()
-  const username = window.location.pathname.split(`/`).slice(-1)[0]
+function onClickFollow(event) {
+  event.stopPropagation();
+  event.preventDefault();
+  const username = window.location.pathname.split(`/`).slice(-1)[0];
   // activate AutoRemoteFollow
-  window.open(`/users/${username}/remote_follow`, `_blank`)
+  window.open(`/users/${username}/remote_follow`, `_blank`);
 }
 
 /**
  * wait for element to appear
  * @param {string} selector
  * @param {number} timeout
+ * @see {@link https://github.com/storybookjs/test-runner/blob/6d41927154e8dd1e4c9e7493122e24e2739a7a0f/src/setup-page.ts#L134} from which this was adapted
  */
-function waitForElement (selector, timeout) {
+function waitForElement(selector, timeout) {
   return new Promise((resolve, reject) => {
     function getElement() {
-      return document.querySelector(selector)
+      return document.querySelector(selector);
     }
 
-    const element = getElement()
+    const element = getElement();
     if(element){
-      return resolve(element)
+      return resolve(element);
     }
 
     const observer = new MutationObserver(() => {
-      const element = getElement()
+      const element = getElement();
       if(element){
-        resolve(element)
-        observer.disconnect()
+        resolve(element);
+        observer.disconnect();
       }
     })
 
     observer.observe(document.body, {
       childList: true,
       subtree: true
-    })
+    });
 
     window.setTimeout(() => {
-      reject()
-    }, timeout)
+      reject();
+    }, timeout);
   }) 
 }
 
 /**
  * Inject replacement onClick handler for Follow button
  */
-async function injectFollowButton () {
+async function injectFollowButton() {
   try {
-    const followButton = await waitForElement(`.account__header__tabs__buttons button.button`, 20000)
-    followButton.addEventListener(`click`, onClickFollow)
+    const followButton = await waitForElement(`.account__header__tabs__buttons button.button`, 20000);
+    followButton.addEventListener(`click`, onClickFollow);
   } catch {
     // Follow button failed to appear
   }
 }
 
-async function init () {
-  let versionNumber
+async function init() {
+  let versionNumber;
 
   try {
-    const initialStateObject = JSON.parse(document.getElementById(`initial-state`).innerHTML)
-    const version = initialStateObject?.meta?.version
+    const initialStateObject = JSON.parse(document.getElementById(`initial-state`).innerHTML);
+    const version = initialStateObject?.meta?.version;
     if(!initialStateObject || !version){
       // not a Mastodon server
-      return
+      return;
     }
 
-    versionNumber = parseVersionNumber(version)
+    versionNumber = parseVersionNumber(version);
   } catch {
     return
   }
 
   
   if(Number.parseInt(versionNumber.major) >= 4){
-    await injectFollowButton()
+    await injectFollowButton();
   }
 }
 
-init()
+init();

--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -1,20 +1,4 @@
-/**
- * @typedef {Object} VersionNumber
- * @property {string} major
- * @property {string} minor
- * @property {string} patch
- */
-
-/**
- * parses a versionNumber string
- * @returns {VersionNumber}
- */
-function parseVersionNumber() {
-  const versionElement = document.querySelector(`.link-footer`).textContent;
-  const versionNumber = versionElement.match(/v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$/);
-  return versionNumber.groups;
-}
-
+"use strict";
 
 /**
  * Replacement onClick handler for Follow button
@@ -77,25 +61,7 @@ async function injectFollowButton() {
 }
 
 async function init() {
-  let versionNumber;
-
-  try {
-    const initialStateObject = JSON.parse(document.getElementById(`initial-state`).innerHTML);
-    const version = initialStateObject?.meta?.version;
-    if(!initialStateObject || !version){
-      // not a Mastodon server
-      return;
-    }
-
-    versionNumber = parseVersionNumber(version);
-  } catch {
-    return
-  }
-
-  
-  if(Number.parseInt(versionNumber.major) >= 4){
-    await injectFollowButton();
-  }
+  await injectFollowButton();
 }
 
 init();

--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -14,7 +14,7 @@ function onClickFollow(event) {
 }
 
 /**
- * wait for element to appear.
+ * Wait for element to appear.
  * @param {string} selector
  * @param {number} timeoutDuration
  * @see {@link https://github.com/storybookjs/test-runner/blob/6d41927154e8dd1e4c9e7493122e24e2739a7a0f/src/setup-page.ts#L134}

--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -1,0 +1,100 @@
+/**
+ * @typedef {Object} VersionNumber
+ * @property {string} major
+ * @property {string} minor
+ * @property {string} patch
+ */
+
+/**
+ * parses a versionNumber string
+ * @returns {VersionNumber}
+ */
+function parseVersionNumber() {
+  const versionElement = document.querySelector(`.link-footer`).textContent
+  const versionNumber = versionElement.match(/v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$/)
+  return versionNumber.groups
+}
+
+
+/**
+ * Replacement onClick handler for Follow button
+ * @param {Event} event 
+ */
+function onClickFollow (event) {
+  event.stopPropagation()
+  event.preventDefault()
+  const username = window.location.pathname.split(`/`).slice(-1)[0]
+  // activate AutoRemoteFollow
+  window.open(`/users/${username}/remote_follow`, `_blank`)
+}
+
+/**
+ * wait for element to appear
+ * @param {string} selector
+ * @param {number} timeout
+ */
+function waitForElement (selector, timeout) {
+  return new Promise((resolve, reject) => {
+    function getElement() {
+      return document.querySelector(selector)
+    }
+
+    const element = getElement()
+    if(element){
+      return resolve(element)
+    }
+
+    const observer = new MutationObserver(() => {
+      const element = getElement()
+      if(element){
+        resolve(element)
+        observer.disconnect()
+      }
+    })
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    })
+
+    window.setTimeout(() => {
+      reject()
+    }, timeout)
+  }) 
+}
+
+/**
+ * Inject replacement onClick handler for Follow button
+ */
+async function injectFollowButton () {
+  try {
+    const followButton = await waitForElement(`.account__header__tabs__buttons button.button`, 20000)
+    followButton.addEventListener(`click`, onClickFollow)
+  } catch {
+    // Follow button failed to appear
+  }
+}
+
+async function init () {
+  let versionNumber
+
+  try {
+    const initialStateObject = JSON.parse(document.getElementById(`initial-state`).innerHTML)
+    const version = initialStateObject?.meta?.version
+    if(!initialStateObject || !version){
+      // not a Mastodon server
+      return
+    }
+
+    versionNumber = parseVersionNumber(version)
+  } catch {
+    return
+  }
+
+  
+  if(Number.parseInt(versionNumber.major) >= 4){
+    await injectFollowButton()
+  }
+}
+
+init()

--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -5,63 +5,64 @@
  * @param {Event} event 
  */
 function onClickFollow(event) {
-  event.stopPropagation();
-  event.preventDefault();
-  const username = window.location.pathname.split(`/`).slice(-1)[0];
-  // activate AutoRemoteFollow
-  window.open(`/users/${username}/remote_follow`, `_blank`);
+    event.stopPropagation();
+    event.preventDefault();
+    const username = window.location.pathname.split(`/`).slice(-1)[0];
+    // activate AutoRemoteFollow
+    window.open(`/users/${username}/remote_follow`, `_blank`);
 }
 
 /**
  * wait for element to appear
  * @param {string} selector
  * @param {number} timeout
- * @see {@link https://github.com/storybookjs/test-runner/blob/6d41927154e8dd1e4c9e7493122e24e2739a7a0f/src/setup-page.ts#L134} from which this was adapted
+ * @see {@link https://github.com/storybookjs/test-runner/blob/6d41927154e8dd1e4c9e7493122e24e2739a7a0f/src/setup-page.ts#L134}
+ *  from which this was adapted
  */
 function waitForElement(selector, timeout) {
-  return new Promise((resolve, reject) => {
-    function getElement() {
-      return document.querySelector(selector);
-    }
+    return new Promise((resolve, reject) => {
+        function getElement() {
+            return document.querySelector(selector);
+        }
 
-    const element = getElement();
-    if(element){
-      return resolve(element);
-    }
+        const element = getElement();
+        if(element){
+            return resolve(element);
+        }
 
-    const observer = new MutationObserver(() => {
-      const element = getElement();
-      if(element){
-        resolve(element);
-        observer.disconnect();
-      }
-    })
+        const observer = new MutationObserver(() => {
+        const element = getElement();
+        if(element){
+            resolve(element);
+            observer.disconnect();
+        }
+        });
 
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true
-    });
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
 
-    window.setTimeout(() => {
-      reject();
-    }, timeout);
-  }) 
+        window.setTimeout(() => {
+            reject();
+        }, timeout);
+    }); 
 }
 
 /**
  * Inject replacement onClick handler for Follow button
  */
 async function injectFollowButton() {
-  try {
-    const followButton = await waitForElement(`.account__header__tabs__buttons button.button`, 20000);
-    followButton.addEventListener(`click`, onClickFollow);
-  } catch {
-    // Follow button failed to appear
-  }
+    try {
+        const followButton = await waitForElement(`.account__header__tabs__buttons button.button`, 20000);
+        followButton.addEventListener(`click`, onClickFollow);
+    } catch {
+        // Follow button failed to appear
+    }
 }
 
 async function init() {
-  await injectFollowButton();
+    await injectFollowButton();
 }
 
 init();

--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -1,41 +1,47 @@
 "use strict";
 
 /**
- * Replacement onClick handler for Follow button
+ * Replacement onClick handler for Follow button.
  * @param {Event} event 
+ * @returns {void}
  */
 function onClickFollow(event) {
     event.stopPropagation();
     event.preventDefault();
-    const username = window.location.pathname.split(`/`).slice(-1)[0];
+    const username = window.location.pathname.split("/").slice(-1)[0];
     // activate AutoRemoteFollow
-    window.open(`/users/${username}/remote_follow`, `_blank`);
+    window.open(`/users/${username}/remote_follow`, "_blank");
 }
 
 /**
- * wait for element to appear
+ * wait for element to appear.
  * @param {string} selector
- * @param {number} timeout
+ * @param {number} timeoutDuration
  * @see {@link https://github.com/storybookjs/test-runner/blob/6d41927154e8dd1e4c9e7493122e24e2739a7a0f/src/setup-page.ts#L134}
  *  from which this was adapted
+ * @returns {Promise}
  */
-function waitForElement(selector, timeout) {
+function waitForElement(selector, timeoutDuration) {
     return new Promise((resolve, reject) => {
-        function getElement() {
-            return document.querySelector(selector);
-        }
+        const getElement = () => document.querySelector(selector);
+
+        const timeout = window.setTimeout(() => {
+            reject(new Error("waitForElement timed out"));
+        }, timeoutDuration);
 
         const element = getElement();
         if(element){
+            window.clearTimeout(timeout);
             return resolve(element);
         }
 
         const observer = new MutationObserver(() => {
-        const element = getElement();
-        if(element){
-            resolve(element);
-            observer.disconnect();
-        }
+            const element = getElement();
+            if(element){
+                window.clearTimeout(timeout);
+                resolve(element);
+                observer.disconnect();
+            }
         });
 
         observer.observe(document.body, {
@@ -43,24 +49,27 @@ function waitForElement(selector, timeout) {
             subtree: true
         });
 
-        window.setTimeout(() => {
-            reject();
-        }, timeout);
+        return null;
     }); 
 }
 
 /**
- * Inject replacement onClick handler for Follow button
+ * Inject replacement onClick handler for Follow button.
+ * @returns {void}
  */
 async function injectFollowButton() {
     try {
-        const followButton = await waitForElement(`.account__header__tabs__buttons button.button`, 20000);
-        followButton.addEventListener(`click`, onClickFollow);
-    } catch {
+        const followButton = await waitForElement(".account__header__tabs__buttons button:first-of-type", 20000);
+        followButton.addEventListener("click", onClickFollow);
+    } catch (error) {
         // Follow button failed to appear
     }
 }
 
+/**
+ * Initialise injection for Mastodon Follow button.
+ * @returns {void}
+ */
 async function init() {
     await injectFollowButton();
 }


### PR DESCRIPTION
Following works.

Essentially, it injects a content script that checks if the remote instance is v4 Mastodon instance, in which case it replaces the event listener for the Follow button with:

```
window.open(`/users/${username}/remote_follow`, `_blank`)`
```

At that point, the pre-existing `AutoRemoteFollow` module can function as before.

I'll add support for remote interactions soon in this same PR. I have opened a draft PR for now so if there are comments I can take them into account when adding on to the PR.