### PR TITLE
Fix handling URLs where username is not at the end of the path

### DIFF
--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -9,7 +9,7 @@
 function onClickFollow(event) {
     event.stopPropagation();
     event.preventDefault();
-    const username = window.location.pathname.split("/").slice(-1)[0];
+    const username = window.location.pathname.split("/").find(pathPart => pathPart.startsWith('@'));
     // activate AutoRemoteFollow
     window.open(`/users/${username}/remote_follow`, "_blank");
 }


### PR DESCRIPTION
Fixes https://github.com/rugk/mastodon-simplified-federation/issues/93

This PR fixes handling clicking the Follow button while on a URL that doesn't end with the user's username.

For example: `https://mastodon.url/@username/with_replies`

Instead of always using the 0th index, we search for the first occurrence of a path section that start with @, indicating this is the username.