### PR TITLE
Update with French translation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,7 +19,7 @@
 - [@PoorPocketsMcNeuHold](https://github.com/PoorPocketsMcNeuHold)
 - [@le-jun](https://github.com/le-jun)
 - Antonin Del Fabbro ([@AntoninDelFabbro](https://github.com/AntoninDelFabbro))
-- [@amcwb/stars](https://github.com/amcwb/)
+- [@amcwb](https://github.com/amcwb/)
 
 ### German
 

--- a/assets/texts/en/Changelog/next.md
+++ b/assets/texts/en/Changelog/next.md
@@ -1,0 +1,1 @@
+* **Improved:** The translation for French has been improved, see [#122](https://github.com/rugk/mastodon-simplified-federation/pull/122).

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -231,7 +231,7 @@
     "hash": "5f54e42067e19895a2641b17a5233418"
   },
   "ariaMessageSuccess": {
-    "message": "message de validation",
+    "message": "message de succès",
     "description": "the aria label to label the message box as an success message box",
     "hash": "334387b4ae53483d17f11519a70dd3af"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -95,7 +95,7 @@
     "hash": "e46a9b3ba7502d7b5d399f0b9461fc82"
   },
   "permissionRequiredTabs": {
-    "message": "L'autorisation d’accès aux onglets du navigateur est requise pour cette fonction.",
+    "message": "L'autorisation d'accéder aux onglets du navigateur est requise pour cette fonction.",
     "description": "The message shown, when the emojiCopyOnlyFallback option in the settings needs to request permissions to work.",
     "hash": "dce672ef8e244e85b5972c4c4b885a56"
   },
@@ -173,14 +173,14 @@
     "hash": "5e2a6e34c5fed46740dc238f1cc7768a"
   },
   "optionRedirectInMainWindow": {
-    "message": "Bloque l’usage de pop-up.",
+    "message": "Redirection vers la fenêtre principale.",
     "description": "This is an option shown in the add-on settings.",
-    "hash": "dc056fc373c7161104ad81b28884a017"
+    "hash": "67bb7ec7a9bee72e4551070cb2be57bc"
   },
   "optionRedirectInMainWindowDescr": {
-    "message": "Bloque l’usage d’une fenêtre supplémentaire et redirige l’action sur la fenêtre principale.",
+    "message": "Bloque l’usage d’un onglet supplémentaire et redirige l’action sur la page principale.",
     "description": "This is an option shown in the add-on settings.",
-    "hash": "ba0f60f1ae0c6d6785d5eb410247eb11"
+    "hash": "a8f0ba44634e64e41ec2577b195cc5e0"
   },
   "translatorCredit": {
     "message": "Cette extension a été traduite en français par $TRANSLATORS$.",
@@ -211,7 +211,7 @@
   "contributorsThanksLink": {
     "message": "https://github.com/rugk/mastodon-simplified-federation/blob/main/CONTRIBUTORS.md",
     "description": "The link to the CONTRIBUTORS file.",
-    "hash": "1fbeb3813910bf47c53cf596035c27db"
+    "hash": "0261a0a43f3b4c0454d9b0d862e9088c"
   },
   "contributorsThanksLinkText": {
     "message": "toutes les autres personnes ayant contribué",
@@ -231,7 +231,7 @@
     "hash": "5f54e42067e19895a2641b17a5233418"
   },
   "ariaMessageSuccess": {
-    "message": "message de succès",
+    "message": "message de validation",
     "description": "the aria label to label the message box as an success message box",
     "hash": "334387b4ae53483d17f11519a70dd3af"
   },


### PR DESCRIPTION
Follows #121 and replace #122.

I reverted this change, after discussing with Le-jun we agreed the change wasn't necessary.

```diff
- message de validation
+ message de succès
```

(I also approve the idea of [having a mirror](https://codeberg.org/Recommendations/Mirror_to_Codeberg) on Codeberg! Once logged, you can even [import your repo](https://codeberg.org/repo/migrate).)