### PR TITLE
Manifest: Switch application key to browser_specific_settings

### DIFF
--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -39,7 +39,7 @@
     "tabs"
   ],
 
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "mastodon-auto-remote-follow@rugk.github.io",
       "strict_min_version": "61.0"

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -38,7 +38,7 @@
     "tabs"
   ],
 
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "mastodon-auto-remote-follow@rugk.github.io",
       "strict_min_version": "79.0"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,7 +39,7 @@
     "tabs"
   ],
 
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "mastodon-auto-remote-follow@rugk.github.io",
       "strict_min_version": "61.0"


### PR DESCRIPTION
Works with both Manifest v2 and v3, but required for v3. Partial fix for #50