### PR TITLE
Don't leak MutationObserver on waitForElement timeout

### DIFF
--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -169,8 +169,7 @@ function initInjections() {
  */
 async function init() {
     if (typeof MASTODON_INJECTED_CLASS === "undefined"){
-        // eslint-disable-next-line vars-on-top, no-var
-        var MASTODON_INJECTED_CLASS = true;
+        globalThis.MASTODON_INJECTED_CLASS = true;
     } else {
         // init has already run
         return;

--- a/src/content_script/mastodonInject.js
+++ b/src/content_script/mastodonInject.js
@@ -58,6 +58,7 @@ function waitForElement(selector, multiple = false, timeoutDuration = 200000) {
 
         const timeout = window.setTimeout(() => {
             reject(new Error("waitForElement timed out"));
+            observer.disconnect();
         }, timeoutDuration);
 
         const element = getElement();

--- a/src/content_script/misskeyInject.js
+++ b/src/content_script/misskeyInject.js
@@ -120,8 +120,7 @@ function initInjections() {
  */
 async function init() {
     if (typeof MISSKEY_INJECTED === "undefined"){
-        // eslint-disable-next-line vars-on-top, no-var
-        var MISSKEY_INJECTED = true;
+        globalThis.MISSKEY_INJECTED = true;
     } else {
         // init has already run
         return;

--- a/src/content_script/misskeyInject.js
+++ b/src/content_script/misskeyInject.js
@@ -51,6 +51,7 @@ function waitForElement(selector, multiple = false, timeoutDuration = 200000) {
 
         const timeout = window.setTimeout(() => {
             reject(new Error("waitForElement timed out"));
+            observer.disconnect();
         }, timeoutDuration);
 
         const element = getElement();


### PR DESCRIPTION
Right now, if waitForElement times out, the MutationObserver sticks around until it finds the element it's looking for, even though the promise has already been resolved. If the page the script has been injected into isn't a Mastodon/Misskey page, the observer could stick around forever, because the element it's looking for will never be created.

Separately, I don't think this code to prevent repeated init()s works, because the var won't survive after the function returns:

```js
async function init() {
    if (typeof MASTODON_INJECTED_CLASS === "undefined"){
        // eslint-disable-next-line vars-on-top, no-var
        var MASTODON_INJECTED_CLASS = true;
    } else {
        // init has already run
        return;
    }
```

On apps with SPA-like soft navigation, where these scripts run once every time the URL changes, each call to init() leaks more MutationObservers, and if you keep the tab around long enough, enough observers build up to add noticeable lag after DOM writes.

Found this while investigating a profile that @thibaultmol sent me where our app was running slowly. Every time we changed the DOM, 300ms of waitForElement observer callbacks ran afterwards.